### PR TITLE
Chore: Get api url from environment variables in 'Banner' component

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 
 export default function Banner() {
-
     const [email, setEmail] = useState('');
 
     if (localStorage.getItem("subscribed") === "true") {
@@ -18,7 +17,7 @@ export default function Banner() {
         localStorage.setItem("subscribed", true);
         closeBanner(event);
 
-        fetch('https://ecommerce-api-ten-sooty.vercel.app/api/v1/subscribe', {
+        fetch(process.env.REACT_APP_API_URL + '/subscribe', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
We should get the backend link from the environment variable, so we can easily switch between api versions like `v1`, `v2`. All we need to is changing the environment url and restarting it. Otherwise, we have to rebuild the app while the deploy.